### PR TITLE
Update muddy-water.json

### DIFF
--- a/playbook_json/muddy-water.json
+++ b/playbook_json/muddy-water.json
@@ -4060,7 +4060,7 @@
     {
       "type": "malware",
       "id": "malware--dcc9ff40-9de2-4d3e-9388-f15dedd8c6fe",
-      "name": "POWERSTAT",
+      "name": "POWERSTATS",
       "labels": [
         "backdoor"
       ],


### PR DESCRIPTION
Fixed typo for malware name "POWERSTATS", it was missing an s